### PR TITLE
依存パッケージをBepInEx.IL2CPPからBepInEx.Unity.IL2CPPに更新

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,5 +24,5 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v3
         with:
-          path: /home/runner/work/laoplus/laoplus/bin/Debug/netstandard2.1/net.laoplus.LAOPLUS.dll
+          path: /home/runner/work/laoplus/laoplus/bin/Debug/net6.0/net.laoplus.LAOPLUS.dll
           if-no-files-found: error

--- a/Feature/AutoRestartTheFacilityWhenRewarded.cs
+++ b/Feature/AutoRestartTheFacilityWhenRewarded.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Collections;
-using BepInEx.IL2CPP.Utils;
+using BepInEx.Unity.IL2CPP.Utils;
 using HarmonyLib;
 
 namespace LAOPLUS.Feature

--- a/Feature/TitleScreenVersion.cs
+++ b/Feature/TitleScreenVersion.cs
@@ -11,7 +11,7 @@ namespace LAOPLUS.Feature
         static void Postfix(Panel_Title __instance)
         {
             __instance._lblVersion.text +=
-                $"\n{PluginInfo.PLUGIN_NAME} {PluginInfo.PLUGIN_VERSION}";
+                $"\n{MyPluginInfo.PLUGIN_NAME} {MyPluginInfo.PLUGIN_VERSION}";
             LAOPLUS.Log.LogDebug($"TitlePatch: {__instance._lblVersion.text}");
         }
     }

--- a/LAOPLUS.cs
+++ b/LAOPLUS.cs
@@ -1,17 +1,18 @@
 using System;
 using BepInEx;
 using BepInEx.Configuration;
-using BepInEx.IL2CPP;
+using BepInEx.Unity.IL2CPP;
 using BepInEx.Logging;
 using HarmonyLib;
 using System.Collections.Generic;
 using System.Net.Http;
 using System.Reflection;
 using LAOPLUS.Notification;
+using UnityEngine;
 
 namespace LAOPLUS
 {
-    [BepInPlugin(PluginInfo.PLUGIN_GUID, PluginInfo.PLUGIN_NAME, PluginInfo.PLUGIN_VERSION)]
+    [BepInPlugin(MyPluginInfo.PLUGIN_GUID, MyPluginInfo.PLUGIN_NAME, MyPluginInfo.PLUGIN_VERSION)]
     // ReSharper disable once InconsistentNaming
     // ReSharper disable once ClassNeverInstantiated.Global
     public class LAOPLUS : BasePlugin
@@ -114,7 +115,7 @@ namespace LAOPLUS
         {
             Log.LogInfo($"{NotificationClients.Count} notification client(s) loaded.");
             SendMessageToAllNotificationClients(
-                $"{PluginInfo.PLUGIN_NAME} v{PluginInfo.PLUGIN_VERSION} loaded!"
+                $"{MyPluginInfo.PLUGIN_NAME} v{MyPluginInfo.PLUGIN_VERSION} loaded!"
             );
         }
 
@@ -165,11 +166,11 @@ namespace LAOPLUS
         public override void Load()
         {
             Log = base.Log;
-            Log.LogInfo($"{PluginInfo.PLUGIN_NAME} v{PluginInfo.PLUGIN_VERSION} is loaded!");
+            Log.LogInfo($"{MyPluginInfo.PLUGIN_NAME} v{MyPluginInfo.PLUGIN_VERSION} is loaded!");
 
             HttpClient.DefaultRequestHeaders.Add(
                 "User-Agent",
-                $"{PluginInfo.PLUGIN_NAME}/{PluginInfo.PLUGIN_VERSION}"
+                $"{MyPluginInfo.PLUGIN_NAME}/{MyPluginInfo.PLUGIN_VERSION}"
             );
 
             // Discord

--- a/LAOPLUS.csproj
+++ b/LAOPLUS.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>netstandard2.1</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
         <AssemblyName>net.laoplus.LAOPLUS</AssemblyName>
         <Product>LAOPLUS</Product>
         <VersionPrefix>2.1.0</VersionPrefix>
@@ -10,12 +10,18 @@
         <DebugType>none</DebugType>
         <PackageProjectUrl>https://github.com/eai04191/laoplus</PackageProjectUrl>
         <PackageReadmeFile>README.md</PackageReadmeFile>
+        <RestoreAdditionalProjectSources>
+            https://api.nuget.org/v3/index.json;
+            https://nuget.bepinex.dev/v3/index.json;
+            https://nuget.samboy.dev/v3/index.json
+        </RestoreAdditionalProjectSources>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="BepInEx.IL2CPP" Version="6.0.0-*" IncludeAssets="compile" />
-        <PackageReference Include="BepInEx.PluginInfoProps" Version="1.*" />
+        <PackageReference Include="BepInEx.Unity.IL2CPP" Version="6.0.0-be.*" IncludeAssets="compile" />
+        <PackageReference Include="BepInEx.PluginInfoProps" Version="2.*" />
         <PackageReference Include="LastOrigin.GameLibs" Version="*-*" />
+        <PackageReference Include="BepInEx.IL2CPP.MSBuild" Version="2.*" />
     </ItemGroup>
 
     <ItemGroup>

--- a/NuGet.Config
+++ b/NuGet.Config
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <packageSources>
-    <add key="BepInEx" value="https://nuget.bepinex.dev/v3/index.json" />
-  </packageSources>
-</configuration>


### PR DESCRIPTION
- close #132
- 依存パッケージをBepInEx.IL2CPPからBepInEx.Unity.IL2CPPに更新
- targetをnet6.0に更新